### PR TITLE
Use Promise.resolve to allow for undefined promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,18 @@
-'use strict';
+"use strict";
 
 module.exports = promise => {
-	let wrapper = new Promise(resolve => {
-		promise.then(
-			result => resolve([false, result]),
-			error => resolve([true, error])
-		);
-	});
+  let wrapper = new Promise(resolve => {
+    Promise.resolve(promise).then(
+      result => resolve([false, result]),
+      error => resolve([true, error])
+    );
+  });
 
-	return () => new Promise((resolve, reject) => {
-		wrapper.then(([isError, value]) => {
-			if (isError) reject(value);
-			else resolve(value);
-		});
-	});
+  return () =>
+    new Promise((resolve, reject) => {
+      wrapper.then(([isError, value]) => {
+        if (isError) reject(value);
+        else resolve(value);
+      });
+    });
 };

--- a/test.js
+++ b/test.js
@@ -1,33 +1,37 @@
-'use strict';
+"use strict";
 
-const assert = require('assert');
-const delayPromise = require('.');
+const assert = require("assert");
+const delayPromise = require(".");
 
 function wait(ms) {
-	return new Promise(r => setTimeout(r, ms));
+  return new Promise(r => setTimeout(r, ms));
 }
 
 async function waitAndThrow(ms) {
-	await wait(ms);
-	throw 'some error';
+  await wait(ms);
+  throw "some error";
 }
 
 async function test() {
-	let resolving = delayPromise(wait(100));
-	await wait(200);
-	await resolving();
+  let resolving = delayPromise(wait(100));
+  await wait(200);
+  await resolving();
 
-	try {
-		let rejecting = delayPromise(waitAndThrow(100));
-		await wait(200);
-		await rejecting();
-		throw new Error('Did not reject.');
-	} catch(err) {
-		assert(err === 'some error');
-	}
+  try {
+    let rejecting = delayPromise(waitAndThrow(100));
+    await wait(200);
+    await rejecting();
+    throw new Error("Did not reject.");
+  } catch (err) {
+    assert(err === "some error");
+  }
+
+  let notDefined = delayPromise(undefined);
+  await wait(200);
+  await notDefined();
 }
 
 test().catch(err => {
-	console.error(err);
-	process.exit(1);
+  console.error(err);
+  process.exit(1);
 });


### PR DESCRIPTION
`delayPromise()` currently creates an unhandled Promise rejection for non-promise values.

This can be avoided by using `Promise.resolve()`

What do you think? Would you be open for merging this PR and releasing a new version?